### PR TITLE
Updating GPU detection logic to support CPU-only computers

### DIFF
--- a/easyocr/easyocr.py
+++ b/easyocr/easyocr.py
@@ -42,13 +42,18 @@ model_url = {
 
 class Reader(object):
 
-    def __init__(self, lang_list, gpu = True):
+    def __init__(self, lang_list, gpu=True):
 
-        if gpu == True and torch.cuda.is_available(): self.device = 'cuda'
-        elif gpu == False:
+        if gpu is False:
             self.device = 'cpu'
-            print('Using cpu, this module is much faster with gpu')
-        else: self.device = gpu
+            print('Using CPU. Note: This module is much faster with a GPU.')
+        elif not torch.cuda.is_available():
+            self.device = 'cpu'
+            print('CUDA not available - defaulting to CPU. Note: This module is much faster with a GPU.')
+        elif gpu is True:
+            self.device = 'cuda'
+        else:
+            self.device = gpu
 
         # check available languages
         unknown_lang = set(lang_list) - set(all_lang_list)


### PR DESCRIPTION
Hi, thanks for sharing this library. It seems to work well and is very easy to use indeed.

One minor issue is that if you import it on a computer with no GPU without manually specifying `gpu=False`, it will crash with a non-obvious error:

```python
>>> reader = easyocr.Reader(['en'])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/easyocr/easyocr.py", line 166, in __init__
    self.detector = get_detector(DETECTOR_PATH, self.device)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/easyocr/detection.py", line 61, in get_detector
    net.load_state_dict(copyStateDict(torch.load(trained_model, map_location=device)))
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/torch/serialization.py", line 367, in load
    return _load(f, map_location, pickle_module)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/torch/serialization.py", line 538, in _load
    result = unpickler.load()
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/torch/serialization.py", line 504, in persistent_load
    data_type(size), location)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/torch/serialization.py", line 390, in restore_location
    result = map_location(storage, location)
TypeError: 'bool' object is not callable
```

This PR cleans up the device detection slightly so it falls back to CPU with a warning instead:

```python
>>> reader = easyocr.Reader(["en"])
CUDA not available - defaulting to CPU. Note: This module is much faster with a GPU.
```

Otherwise, it should work the same way as before. Feel free to merge if that change is OK with you. Also, feel free to ignore this PR if you prefer it working the way that it is. I just found this way to be a lot easier for a less-experienced user to get started if they didn't have a GPU configured correctly.