### PR TITLE
Fix missing to(device) for DataParallel in detection.py

### DIFF
--- a/easyocr/detection.py
+++ b/easyocr/detection.py
@@ -59,7 +59,7 @@ def get_detector(trained_model, device='cpu'):
         net.load_state_dict(copyStateDict(torch.load(trained_model, map_location=device)))
     else:
         net.load_state_dict(copyStateDict(torch.load(trained_model, map_location=device)))
-        net = torch.nn.DataParallel(net)
+        net = torch.nn.DataParallel(net).to(device)
         cudnn.benchmark = False
 
     net.eval()


### PR DESCRIPTION
Without this, I got the following error message when trying to run it with GPU:

```
module must have its parameters and buffers on device cuda:0 (device_ids[0]) but found one of them on device: cpu
```