### PR TITLE
Minor updates to support production use cases

### DIFF
--- a/easyocr/easyocr.py
+++ b/easyocr/easyocr.py
@@ -206,7 +206,8 @@ class Reader(object):
         if os.path.isfile(detector_path) == False:
             if not self.download_enabled:
                 raise FileNotFoundError("Missing %s and downloads disabled" % detector_path)
-            LOGGER.info('Downloading detection model, please wait')
+            LOGGER.warning('Downloading detection model, please wait. '
+                           'This may take several minutes depending upon your network connection.')
             urlretrieve(model_url['detector'][0] , detector_path)
             assert calculate_md5(detector_path) == model_url['detector'][1], corrupt_msg
             LOGGER.info('Download complete')
@@ -215,23 +216,26 @@ class Reader(object):
                 raise FileNotFoundError("MD5 mismatch for %s and downloads disabled" % detector_path)
             LOGGER.warning(corrupt_msg)
             os.remove(detector_path)
-            LOGGER.info('Re-downloading the detection model, please wait')
+            LOGGER.warning('Re-downloading the detection model, please wait. '
+                           'This may take several minutes depending upon your network connection.')
             urlretrieve(model_url['detector'][0], detector_path)
             assert calculate_md5(detector_path) == model_url['detector'][1], corrupt_msg
         # check model file
         if os.path.isfile(model_path) == False:
             if not self.download_enabled:
                 raise FileNotFoundError("Missing %s and downloads disabled" % model_path)
-            LOGGER.info('Downloading recognition model, please wait')
+            LOGGER.warning('Downloading recognition model, please wait. '
+                           'This may take several minutes depending upon your network connection.')
             urlretrieve(model_url[model_file][0], model_path)
             assert calculate_md5(model_path) == model_url[model_file][1], corrupt_msg
-            LOGGER.info('Download complete')
+            LOGGER.info('Download complete.')
         elif calculate_md5(model_path) != model_url[model_file][1]:
             if not self.download_enabled:
                 raise FileNotFoundError("MD5 mismatch for %s and downloads disabled" % model_path)
             LOGGER.warning(corrupt_msg)
             os.remove(model_path)
-            LOGGER.info('Re-downloading the recognition model, please wait')
+            LOGGER.warning('Re-downloading the recognition model, please wait. '
+                           'This may take several minutes depending upon your network connection.')
             urlretrieve(model_url[model_file][0], model_path)
             assert calculate_md5(model_path) == model_url[model_file][1], corrupt_msg
             LOGGER.info('Download complete')

--- a/easyocr/easyocr.py
+++ b/easyocr/easyocr.py
@@ -22,8 +22,9 @@ else:
 LOGGER = getLogger(__name__)
 
 BASE_PATH = os.path.dirname(__file__)
-MODULE_PATH = os.environ.get("MODULE_PATH",
-                             os.path.expanduser("~/.EasyOCR/"))
+MODULE_PATH = os.environ.get("EASYOCR_MODULE_PATH") or \
+              os.environ.get("MODULE_PATH") or \
+              os.path.expanduser("~/.EasyOCR/")
 Path(MODULE_PATH+'/model').mkdir(parents=True, exist_ok=True)
 
 # detector parameters

--- a/easyocr/easyocr.py
+++ b/easyocr/easyocr.py
@@ -62,13 +62,13 @@ class Reader(object):
         """Create an EasyOCR Reader.
 
         Parameters:
-            lang_list (list): Language codes (ISO 639) for languages to recognized during analysis.
+            lang_list (list): Language codes (ISO 639) for languages to be recognized during analysis.
 
             gpu (bool): Enable GPU support (default)
 
             model_storage_directory (string): Path to directory for model data. If not specified,
             models will be read from a directory as defined by the environment variable
-            EASYOCR_MODULE_PATH (prefered), MODULE_PATH (if defined), or ~/.EasyOCR/.
+            EASYOCR_MODULE_PATH (preferred), MODULE_PATH (if defined), or ~/.EasyOCR/.
 
             download_enabled (bool): Enabled downloading of model data via HTTP (default).
         """

--- a/easyocr/utils.py
+++ b/easyocr/utils.py
@@ -490,9 +490,6 @@ def calculate_md5(fname):
             hash_md5.update(chunk)
     return hash_md5.hexdigest()
 
-def eprint(str):
-    print(str, file=sys.stderr)
-
 def get_paragraph(raw_result, x_ths=1, y_ths=0.5, mode = 'ltr'):
     # create basic attributes
     box_group = []


### PR DESCRIPTION
Hi,

I saw your post on HackerNews a while back and had a chance to play with the EasyOCR package today. These are some minor updates that enable use of the EasyOCR module in certain production setups that I wanted to contribute back to you.

 * Use Python logger instead of printing to STDERR. This allows logger statements to be managed and flow according to whatever logging configuration is needed by the application. For example, some production systems will use a JSON-formatted logger setup. Printing directly to STDERR can either cause the errors to be lost or be non-parseable by these types of production setups.

 * Adds two optional arguments to init(): model_storage_directory and download_enabled. I have implemented these as fully backwards-compatible with your prior logic.
    * When model_storage_directory is set, models are read from (and downloaded to) to the path directory. This is necessary because, in some production setups, it is not possible to write to the ~/ directory. Additionally, setting MODULE_PATH as an ENV variable may not be possible or may be confusing.
    * When download_enabled is set to false, this PR causes the code to raise an exception when the model file is missing. (Downloads may not be permitted in some production setups.)

Please let me know your thoughts or if you have any suggestions for adjustments or changes.

Thanks,
-Jeff