### PR TITLE
Estimate number of characters in textbox

### DIFF
--- a/easyocr/detection.py
+++ b/easyocr/detection.py
@@ -47,6 +47,9 @@ def test_net(canvas_size, mag_ratio, net, image, text_threshold, link_threshold,
     # coordinate adjustment
     boxes = adjustResultCoordinates(boxes, ratio_w, ratio_h)
     polys = adjustResultCoordinates(polys, ratio_w, ratio_h)
+    if estimate_num_chars:
+        boxes = list(boxes)
+        polys = list(polys)
     for k in range(len(polys)):
         if estimate_num_chars:
             boxes[k] = (boxes[k], mapper[k])

--- a/easyocr/easyocr.py
+++ b/easyocr/easyocr.py
@@ -269,17 +269,18 @@ class Reader(object):
     def detect(self, img, min_size = 20, text_threshold = 0.7, low_text = 0.4,\
                link_threshold = 0.4,canvas_size = 2560, mag_ratio = 1.,\
                slope_ths = 0.1, ycenter_ths = 0.5, height_ths = 0.5,\
-               width_ths = 0.5, add_margin = 0.1, reformat=True):
+               width_ths = 0.5, add_margin = 0.1, reformat=True, optimal_num_chars=None):
 
         if reformat:
             img, img_cv_grey = reformat_input(img)
 
         text_box = get_textbox(self.detector, img, canvas_size, mag_ratio,\
                                text_threshold, link_threshold, low_text,\
-                               False, self.device)
+                               False, self.device, optimal_num_chars)
         horizontal_list, free_list = group_text_box(text_box, slope_ths,\
                                                     ycenter_ths, height_ths,\
-                                                    width_ths, add_margin)
+                                                    width_ths, add_margin, \
+                                                    (optimal_num_chars is None))
 
         if min_size:
             horizontal_list = [i for i in horizontal_list if max(i[1]-i[0],i[3]-i[2]) > min_size]

--- a/easyocr/utils.py
+++ b/easyocr/utils.py
@@ -404,7 +404,7 @@ def four_point_transform(image, rect):
 
     return warped
 
-def group_text_box(polys, slope_ths = 0.1, ycenter_ths = 0.5, height_ths = 0.5, width_ths = 1.0, add_margin = 0.05):
+def group_text_box(polys, slope_ths = 0.1, ycenter_ths = 0.5, height_ths = 0.5, width_ths = 1.0, add_margin = 0.05, sort_output = True):
     # poly top-left, top-right, low-right, low-left
     horizontal_list, free_list,combined_list, merged_list = [],[],[],[]
 
@@ -434,7 +434,8 @@ def group_text_box(polys, slope_ths = 0.1, ycenter_ths = 0.5, height_ths = 0.5, 
             y4 = poly[7] + np.sin(theta24)*margin
 
             free_list.append([[x1,y1],[x2,y2],[x3,y3],[x4,y4]])
-    horizontal_list = sorted(horizontal_list, key=lambda item: item[4])
+    if sort_output:
+        horizontal_list = sorted(horizontal_list, key=lambda item: item[4])
 
     # combine box
     new_box = []
@@ -500,7 +501,7 @@ def group_text_box(polys, slope_ths = 0.1, ycenter_ths = 0.5, height_ths = 0.5, 
     # may need to check if box is really in image
     return merged_list, free_list
 
-def get_image_list(horizontal_list, free_list, img, model_height = 64):
+def get_image_list(horizontal_list, free_list, img, model_height = 64, sort_output = True):
     image_list = []
     maximum_y,maximum_x = img.shape
 
@@ -532,7 +533,8 @@ def get_image_list(horizontal_list, free_list, img, model_height = 64):
     max_ratio = max(max_ratio_hori, max_ratio_free)
     max_width = math.ceil(max_ratio)*model_height
 
-    image_list = sorted(image_list, key=lambda item: item[0][0][1]) # sort by vertical position
+    if sort_output:
+        image_list = sorted(image_list, key=lambda item: item[0][0][1]) # sort by vertical position
     return image_list, max_width
 
 def download_and_unzip(url, filename, model_storage_directory):


### PR DESCRIPTION
This PR introduces the ability to estimate the number of characters in each textbox, first mentioned in Issue #311 .  It adds the optional argument `optimal_num_chars` to the `detect` function, which represents the optimal number of characters in each text box.

The output of the `detect` function remains a list of text boxes. However, if for example a user is looking for a 10-digit serial number, setting `optimal_num_chars=10` will estimate the number of characters in each text box, and sort the output such that text boxes with around 10 characters are put first. This way, when the user loops through this list calling `predict` on each textbox, they are able to find the desired e.g. serial number quickly.

As I mentioned in the issue, I found this useful in my case - happy to make any changes to improve it / make the approach more general!