### PR TITLE
Fix bug group text box when a y_center of the big boxes almost equal to a y_center of the smaller boxes.

### DIFF
--- a/easyocr/utils.py
+++ b/easyocr/utils.py
@@ -474,7 +474,7 @@ def group_text_box(polys, slope_ths = 0.1, ycenter_ths = 0.5, height_ths = 0.5, 
                     x_max = box[1]
                     new_box.append(box)
                 else:
-                    if (abs(np.mean(b_height) - box[5]) < height_ths*np.mean(b_height)) and (abs(box[0]-x_max) < width_ths *(box[1]-box[0])): # merge boxes
+                    if (abs(np.mean(b_height) - box[5]) < height_ths*np.mean(b_height)) and (abs(box[0]-x_max) < width_ths *(box[3]-box[2])): # merge boxes
                         b_height.append(box[5])
                         x_max = box[1]
                         new_box.append(box)

--- a/easyocr/utils.py
+++ b/easyocr/utils.py
@@ -447,7 +447,7 @@ def group_text_box(polys, slope_ths = 0.1, ycenter_ths = 0.5, height_ths = 0.5, 
             new_box.append(poly)
         else:
             # comparable height and comparable y_center level up to ths*height
-            if (abs(np.mean(b_height) - poly[5]) < height_ths*np.mean(b_height)) and (abs(np.mean(b_ycenter) - poly[4]) < ycenter_ths*np.mean(b_height)):
+            if abs(np.mean(b_ycenter) - poly[4]) < ycenter_ths*np.mean(b_height):    
                 b_height.append(poly[5])
                 b_ycenter.append(poly[4])
                 new_box.append(poly)
@@ -470,13 +470,16 @@ def group_text_box(polys, slope_ths = 0.1, ycenter_ths = 0.5, height_ths = 0.5, 
             merged_box, new_box = [],[]
             for box in boxes:
                 if len(new_box) == 0:
+                    b_height = [box[5]]
                     x_max = box[1]
                     new_box.append(box)
                 else:
-                    if abs(box[0]-x_max) < width_ths *(box[3]-box[2]): # merge boxes
+                    if (abs(np.mean(b_height) - box[5]) < height_ths*np.mean(b_height)) and (abs(box[0]-x_max) < width_ths *(box[3]-box[2])): # merge boxes
+                        b_height.append(box[5])
                         x_max = box[1]
                         new_box.append(box)
                     else:
+                        b_height = [box[5]]
                         x_max = box[1]
                         merged_box.append(new_box)
                         new_box = [box]

--- a/easyocr/utils.py
+++ b/easyocr/utils.py
@@ -474,7 +474,7 @@ def group_text_box(polys, slope_ths = 0.1, ycenter_ths = 0.5, height_ths = 0.5, 
                     x_max = box[1]
                     new_box.append(box)
                 else:
-                    if (abs(np.mean(b_height) - box[5]) < height_ths*np.mean(b_height)) and (abs(box[0]-x_max) < width_ths *(box[3]-box[2])): # merge boxes
+                    if (abs(np.mean(b_height) - box[5]) < height_ths*np.mean(b_height)) and (abs(box[0]-x_max) < width_ths *(box[1]-box[0])): # merge boxes
                         b_height.append(box[5])
                         x_max = box[1]
                         new_box.append(box)


### PR DESCRIPTION
Fix bug group_text_box(...) when a y_center of the big boxes almost equal to a y_center of the smaller boxes.

In my example, after running over "horizontal_list = sorted(horizontal_list, key=lambda item: item[4])", a big box will be arranged in the middle of the small boxes, their y_center are nearly equal. Next, when we group them by compare height_ths and ycenter_ths, the big box will separate the small boxes into parts instead of one, the small boxes will be split further after checking with width_ths.

I think, we should to checking height_ths after group it the lines by y_center, do sort again, then checking height_ths and widthd_ths. This will stop a big box separate a same y_center group of the small box , whereas the big box is not really in between them

This is a sample image
https://drive.google.com/file/d/1B1ceHvWL4e5BJ-rD7Z7dL8H8agtJBisv/view