### PR TITLE
Feature: Add `verbose` parameter to `Reader` class to hide download progressbar

### DIFF
--- a/easyocr/easyocr.py
+++ b/easyocr/easyocr.py
@@ -30,7 +30,8 @@ class Reader(object):
 
     def __init__(self, lang_list, gpu=True, model_storage_directory=None,
                  user_network_directory=None, recog_network = 'standard',
-                 download_enabled=True, detector=True, recognizer=True):
+                 download_enabled=True, detector=True, recognizer=True,
+                 verbose=True):
         """Create an EasyOCR Reader.
 
         Parameters:
@@ -81,7 +82,7 @@ class Reader(object):
                     raise FileNotFoundError("Missing %s and downloads disabled" % detector_path)
                 LOGGER.warning('Downloading detection model, please wait. '
                                'This may take several minutes depending upon your network connection.')
-                download_and_unzip(model_url['detector'][0], DETECTOR_FILENAME, self.model_storage_directory)
+                download_and_unzip(model_url['detector'][0], DETECTOR_FILENAME, self.model_storage_directory, verbose)
                 assert calculate_md5(detector_path) == model_url['detector'][1], corrupt_msg
                 LOGGER.info('Download complete')
             elif calculate_md5(detector_path) != model_url['detector'][1]:
@@ -91,7 +92,7 @@ class Reader(object):
                 os.remove(detector_path)
                 LOGGER.warning('Re-downloading the detection model, please wait. '
                                'This may take several minutes depending upon your network connection.')
-                download_and_unzip(model_url['detector'][0], DETECTOR_FILENAME, self.model_storage_directory)
+                download_and_unzip(model_url['detector'][0], DETECTOR_FILENAME, self.model_storage_directory, verbose)
                 assert calculate_md5(detector_path) == model_url['detector'][1], corrupt_msg
 
         # recognition model
@@ -204,7 +205,7 @@ class Reader(object):
                         raise FileNotFoundError("Missing %s and downloads disabled" % model_path)
                     LOGGER.warning('Downloading recognition model, please wait. '
                                    'This may take several minutes depending upon your network connection.')
-                    download_and_unzip(model_url[model_file][0], model_file, self.model_storage_directory)
+                    download_and_unzip(model_url[model_file][0], model_file, self.model_storage_directory, verbose)
                     assert calculate_md5(model_path) == model_url[model_file][1], corrupt_msg
                     LOGGER.info('Download complete.')
                 elif calculate_md5(model_path) != model_url[model_file][1]:
@@ -214,7 +215,7 @@ class Reader(object):
                     os.remove(model_path)
                     LOGGER.warning('Re-downloading the recognition model, please wait. '
                                    'This may take several minutes depending upon your network connection.')
-                    download_and_unzip(model_url[model_file][0], model_file, self.model_storage_directory)
+                    download_and_unzip(model_url[model_file][0], model_file, self.model_storage_directory, verbose)
                     assert calculate_md5(model_path) == model_url[model_file][1], corrupt_msg
                     LOGGER.info('Download complete')
 

--- a/easyocr/utils.py
+++ b/easyocr/utils.py
@@ -547,9 +547,10 @@ def get_image_list(horizontal_list, free_list, img, model_height = 64, sort_outp
         image_list = sorted(image_list, key=lambda item: item[0][0][1]) # sort by vertical position
     return image_list, max_width
 
-def download_and_unzip(url, filename, model_storage_directory):
+def download_and_unzip(url, filename, model_storage_directory, verbose=True):
     zip_path = os.path.join(model_storage_directory, 'temp.zip')
-    urlretrieve(url, zip_path,reporthook=printProgressBar(prefix = 'Progress:', suffix = 'Complete', length = 50))
+    reporthook = printProgressBar(prefix='Progress:', suffix='Complete', length=50) if verbose else None
+    urlretrieve(url, zip_path, reporthook=reporthook)
     with ZipFile(zip_path, 'r') as zipObj:
         zipObj.extract(filename, model_storage_directory)
     os.remove(zip_path)


### PR DESCRIPTION
### Summary
This allows users to hide the progress-bar when executing the code.

### Problem
In automatic builds using docker, the logs get polluted by the progress-bar (it is printed again and again at each step as it doesn't do an update).

### Solution
The class `Reader` gains a new parameter `verbose` which is passed to the `utils.download_and_unzip` function.