### PR TITLE
raise ValueError instead LOGGER.warning and support PIL image for Rea…

### DIFF
--- a/easyocr/utils.py
+++ b/easyocr/utils.py
@@ -5,7 +5,7 @@ import pickle
 import numpy as np
 import math
 import cv2
-from PIL import Image
+from PIL import Image, JpegImagePlugin
 import hashlib
 import sys, os
 from zipfile import ZipFile
@@ -681,8 +681,12 @@ def reformat_input(image):
             img = image[:,:,:3]
             img = cv2.cvtColor(img, cv2.COLOR_RGB2BGR)
             img_cv_grey = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+    elif type(image) == JpegImagePlugin.JpegImageFile:
+        image_array = np.array(image)
+        img = cv2.cvtColor(image_array, cv2.COLOR_RGB2BGR)
+        img_cv_grey = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
     else:
-        LOGGER.warning('Invalid input type. Suppoting format = string(file path or url), bytes, numpy array')
+        raise ValueError('Invalid input type. Suppoting format = string(file path or url), bytes, numpy array')
 
     return img, img_cv_grey
 


### PR DESCRIPTION
Hi, 
I want to fix some minor issues in easyocr/utils.py which are:
- Raise ValueError instead LOGGER.warning when image object is not supported since LOGGER is not defined yet in easyocr/utils.py
- Adding support for PIL image in Reader.readtext()