### PR TITLE
Faster greedy decoding and support for 3D grayscale

### DIFF
--- a/easyocr/recognition.py
+++ b/easyocr/recognition.py
@@ -125,7 +125,7 @@ def recognizer_predict(model, converter, test_loader, batch_max_length,\
                 # Select max probabilty (greedy decoding) then decode index to character
                 _, preds_index = preds_prob.max(2)
                 preds_index = preds_index.view(-1)
-                preds_str = converter.decode_greedy(preds_index.data, preds_size.data)
+                preds_str = converter.decode_greedy(preds_index.data.cpu().detach().numpy(), preds_size.data)
             elif decoder == 'beamsearch':
                 k = preds_prob.cpu().detach().numpy()
                 preds_str = converter.decode_beamsearch(k, beamWidth=beamWidth)


### PR DESCRIPTION
- MUCH faster greedy decoding function: 20-1000x (+) speedup, which in turn, speeds up the whole ocr process by 1.1-2x. The bigger the text the bigger the speedup. The difference is noticeable when scanning multiple images. One of my scans used to take ~2700s with 900s greedy decoding time. Now, the decoding part takes 1.5s (Added some comments to explain the vectorization process). On a side note, I'm not sure why there is a `for` loop for the elements of the `length` tensor (arg in `decode_greedy`), since in my testing, the tensor always had 1 element.
- Support for 3D grayscale arrays (MxNx1) .