### PR TITLE
Update easyocr.py

### DIFF
--- a/easyocr/easyocr.py
+++ b/easyocr/easyocr.py
@@ -204,10 +204,8 @@ class Reader(object):
             imgH = recog_config['imgH']
             available_lang = recog_config['lang_list']
             self.setModelLanguage(recog_network, lang_list, available_lang, available_lang)
-            #char_file = os.path.join(self.user_network_directory, recog_network+ '.txt')
             self.character = recog_config['character_list']
-            model_file = recog_network+ '.pth'
-            model_path = os.path.join(self.model_storage_directory, model_file)
+            model_path = os.path.join(self.user_network_directory, recog_network+ '.pth')
             self.setLanguageList(lang_list, None)
 
         dict_list = {}


### PR DESCRIPTION
When using a user-defined model,'user_network_directory' should be used instead of'model_storage_directory'.