### PR TITLE
Vertical Text Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ ENV/
 
 # macOS
 *.DS_Store
+
+#virtual env
+ .vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "/Users/mendeza/anaconda3/envs/easy-ocr-env/bin/python"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/Users/mendeza/anaconda3/envs/easy-ocr-env/bin/python"
+}

--- a/easyocr/utils.py
+++ b/easyocr/utils.py
@@ -511,6 +511,29 @@ def group_text_box(polys, slope_ths = 0.1, ycenter_ths = 0.5, height_ths = 0.5, 
     # may need to check if box is really in image
     return merged_list, free_list
 
+def calculate_ratio(width,height):
+    '''
+    Calculate aspect ratio for normal use case (w>h) and vertical text (h>w)
+    '''
+    ratio = width/height
+    if ratio<1.0:
+        ratio = 1./ratio
+    return ratio
+
+def compute_ratio_and_resize(img,width,height,model_height):
+    '''
+    Calculate ratio and resize correctly for both horizontal text
+    and vertical case
+    '''
+    ratio = width/height
+    if ratio<1.0:
+        ratio = calculate_ratio(width,height)
+        img = cv2.resize(img,(model_height,int(model_height*ratio)), interpolation=Image.ANTIALIAS)
+    else:
+        img = cv2.resize(img,(int(model_height*ratio),model_height),interpolation=Image.ANTIALIAS)
+    return img,ratio
+
+
 def get_image_list(horizontal_list, free_list, img, model_height = 64, sort_output = True):
     image_list = []
     maximum_y,maximum_x = img.shape
@@ -519,12 +542,12 @@ def get_image_list(horizontal_list, free_list, img, model_height = 64, sort_outp
     for box in free_list:
         rect = np.array(box, dtype = "float32")
         transformed_img = four_point_transform(img, rect)
-        ratio = transformed_img.shape[1]/transformed_img.shape[0]
+        ratio = calculate_ratio(transformed_img.shape[1],transformed_img.shape[0])
         new_width = int(model_height*ratio)
         if new_width == 0:
             pass
         else:
-            crop_img = cv2.resize(transformed_img, (new_width, model_height), interpolation =  Image.ANTIALIAS)
+            crop_img,ratio = compute_ratio_and_resize(transformed_img,transformed_img.shape[1],transformed_img.shape[0],model_height)
             image_list.append( (box,crop_img) ) # box = [[x1,y1],[x2,y2],[x3,y3],[x4,y4]]
             max_ratio_free = max(ratio, max_ratio_free)
 
@@ -539,12 +562,12 @@ def get_image_list(horizontal_list, free_list, img, model_height = 64, sort_outp
         crop_img = img[y_min : y_max, x_min:x_max]
         width = x_max - x_min
         height = y_max - y_min
-        ratio = width/height
+        ratio = calculate_ratio(width,height)
         new_width = int(model_height*ratio)
         if new_width == 0:
             pass
         else:
-            crop_img = cv2.resize(crop_img, (new_width, model_height), interpolation =  Image.ANTIALIAS)
+            crop_img,ratio = compute_ratio_and_resize(crop_img,width,height,model_height)
             image_list.append( ( [[x_min,y_min],[x_max,y_min],[x_max,y_max],[x_min,y_max]] ,crop_img) )
             max_ratio_hori = max(ratio, max_ratio_hori)
 
@@ -707,17 +730,30 @@ def make_rotated_img_list(rotationInfo, img_list):
     result_img_list = img_list[:]
 
     # add rotated images to original image_list
+    max_ratio=1
     if 90 in rotationInfo:
         for img_info in img_list:
-            result_img_list.append((img_info[0], cv2.rotate(img_info[1], cv2.ROTATE_90_COUNTERCLOCKWISE)))
+            ninty_image = cv2.rotate(img_info[1],cv2.ROTATE_90_COUNTERCLOCKWISE)
+            height,width = ninty_image.shape
+            ratio = calculate_ratio(width,height)
+            max_ratio = max(max_ratio,ratio)
+            result_img_list.append((img_info[0],ninty_image))
 
     if 180 in rotationInfo:
         for img_info in img_list:
-            result_img_list.append((img_info[0], cv2.rotate(img_info[1], cv2.ROTATE_180)))
+            one_eighty_image = cv2.rotate(img_info[1],cv2.ROTATE_180)
+            height,width = one_eighty_image.shape
+            ratio = calculate_ratio(width,height)
+            max_ratio = max(max_ratio,ratio)
+            result_img_list.append((img_info[0], one_eighty_image))
 
     if 270 in rotationInfo:
         for img_info in img_list:
-            result_img_list.append((img_info[0], cv2.rotate(img_info[1], cv2.ROTATE_90_CLOCKWISE)))
+            two_seventy_image = cv2.rotate(img_info[1], cv2.ROTATE_90_CLOCKWISE)
+            height,width = two_seventy_image.shape
+            ratio = calculate_ratio(width,height)
+            max_ratio = max(max_ratio,ratio)
+            result_img_list.append((img_info[0],two_seventy_image))
 
     return result_img_list
 


### PR DESCRIPTION
Hi there, This PR resolves issue #382. @miliadis and I worked together and successfully resolved this issue by having the aspect ratio and resize method adapt when width > height and height > width. Currently the cropped regions in `horizontal_list` and `free_list` are resized so the height fits the `model_height`([L523](https://github.com/JaidedAI/EasyOCR/blob/2e94e151ba00540f633d7a6cb595c99a7e74dbab/easyocr/utils.py#L523) and [L543](https://github.com/JaidedAI/EasyOCR/blob/2e94e151ba00540f633d7a6cb595c99a7e74dbab/easyocr/utils.py#L543)).

The image resizing is calculated by computing the aspect ratio, which is width/height ([L522](https://github.com/JaidedAI/EasyOCR/blob/2e94e151ba00540f633d7a6cb595c99a7e74dbab/easyocr/utils.py#L522) and [L542](https://github.com/JaidedAI/EasyOCR/blob/2e94e151ba00540f633d7a6cb595c99a7e74dbab/easyocr/utils.py#L542)). Assuming the aspect ratio should only be calculated as width/height results in a bug when the cropped region resolution is reduced. When height>width, aspect ratio is <1.0, which results in the resolution of the image being significantly reduced. This then results in poor performance in the CRNN to recognize the text, even when you set the Reader to recognize in several orientations.

Our solution flips the resizing and aspect ratio calculation when the aspect ratio is < 1.0.

To ensure that the max_width is correctly captured, we also updated the [make_rotated_img_list()](https://github.com/JaidedAI/EasyOCR/blob/2e94e151ba00540f633d7a6cb595c99a7e74dbab/easyocr/utils.py#L706) function to capture the max_width in all orientation configurations.

Here is an example notebook that shows the latest EasyOCR performance on a simple text in vertical orientation.

https://colab.research.google.com/drive/1df-dv7IUF0AzaWUwizRspeHr59lm7aeP?authuser=1#scrollTo=-VepZ4LZXMD-

![coronavirus_rotated](https://user-images.githubusercontent.com/5833510/121222379-817a0e00-c854-11eb-82d1-ada222260c94.png)
`[([[1, 1], [21, 1], [21, 127], [1, 127]], 'W', 0.3783025082953806)]`


And here is a demo with our solution showing EasyOCR can now recognize vertical text:

https://colab.research.google.com/drive/1uDXl8yd18LLPsnSd2jFZ3kj0B5_-lkjk?authuser=1#scrollTo=CU8FzHcoIgCv
![coronavirus_rotated](https://user-images.githubusercontent.com/5833510/121222379-817a0e00-c854-11eb-82d1-ada222260c94.png)
`[([[1, 1], [21, 1], [21, 127], [1, 127]], 'coronavirus', 0.6846225781041564)]`