### PR TITLE
Add batch img inference support for ocr det with readtext_batched

### DIFF
--- a/easyocr/detection.py
+++ b/easyocr/detection.py
@@ -22,42 +22,55 @@ def copyStateDict(state_dict):
     return new_state_dict
 
 def test_net(canvas_size, mag_ratio, net, image, text_threshold, link_threshold, low_text, poly, device, estimate_num_chars=False):
-    # resize
-    img_resized, target_ratio, size_heatmap = resize_aspect_ratio(image, canvas_size,\
-                                                                          interpolation=cv2.INTER_LINEAR, mag_ratio=mag_ratio)
-    ratio_h = ratio_w = 1 / target_ratio
+    if isinstance(image, np.ndarray) and len(image.shape) == 4:  # image is batch of np arrays
+        image_arrs = image
+    else:                                                        # image is single numpy array
+        image_arrs = [image]
 
+    img_resized_list = []
+    # resize
+    for img in image_arrs:
+        img_resized, target_ratio, size_heatmap = resize_aspect_ratio(img, canvas_size,
+                                                                      interpolation=cv2.INTER_LINEAR,
+                                                                      mag_ratio=mag_ratio)
+        img_resized_list.append(img_resized)
+    ratio_h = ratio_w = 1 / target_ratio
     # preprocessing
-    x = normalizeMeanVariance(img_resized)
-    x = torch.from_numpy(x).permute(2, 0, 1)    # [h, w, c] to [c, h, w]
-    x = Variable(x.unsqueeze(0))                # [c, h, w] to [b, c, h, w]
+    x = np.array([normalizeMeanVariance(n_img) for n_img in img_resized_list])
+    x = Variable(torch.from_numpy(x).permute(0, 3, 1, 2))  # [b,h,w,c] to [b,c,h,w]
     x = x.to(device)
 
     # forward pass
     with torch.no_grad():
         y, feature = net(x)
 
-    # make score and link map
-    score_text = y[0,:,:,0].cpu().data.numpy()
-    score_link = y[0,:,:,1].cpu().data.numpy()
+    boxes_list, polys_list = [], []
+    for out in y:
+        # make score and link map
+        score_text = out[:, :, 0].cpu().data.numpy()
+        score_link = out[:, :, 1].cpu().data.numpy()
 
-    # Post-processing
-    boxes, polys, mapper = getDetBoxes(score_text, score_link, text_threshold, link_threshold, low_text, poly, estimate_num_chars)
+        # Post-processing
+        boxes, polys, mapper = getDetBoxes(
+            score_text, score_link, text_threshold, link_threshold, low_text, poly, estimate_num_chars)
 
-    # coordinate adjustment
-    boxes = adjustResultCoordinates(boxes, ratio_w, ratio_h)
-    polys = adjustResultCoordinates(polys, ratio_w, ratio_h)
-    if estimate_num_chars:
-        boxes = list(boxes)
-        polys = list(polys)
-    for k in range(len(polys)):
+        # coordinate adjustment
+        boxes = adjustResultCoordinates(boxes, ratio_w, ratio_h)
+        polys = adjustResultCoordinates(polys, ratio_w, ratio_h)
         if estimate_num_chars:
-            boxes[k] = (boxes[k], mapper[k])
-        if polys[k] is None: polys[k] = boxes[k]
+            boxes = list(boxes)
+            polys = list(polys)
+        for k in range(len(polys)):
+            if estimate_num_chars:
+                boxes[k] = (boxes[k], mapper[k])
+            if polys[k] is None:
+                polys[k] = boxes[k]
+        boxes_list.append(boxes)
+        polys_list.append(polys)
 
-    return boxes, polys
+    return boxes_list, polys_list
 
-def get_detector(trained_model, device='cpu', quantize=True):
+def get_detector(trained_model, device='cpu', quantize=True, cudnn_benchmark=False):
     net = CRAFT()
 
     if device == 'cpu':
@@ -70,7 +83,7 @@ def get_detector(trained_model, device='cpu', quantize=True):
     else:
         net.load_state_dict(copyStateDict(torch.load(trained_model, map_location=device)))
         net = torch.nn.DataParallel(net).to(device)
-        cudnn.benchmark = False
+        cudnn.benchmark = cudnn_benchmark
 
     net.eval()
     return net
@@ -78,13 +91,19 @@ def get_detector(trained_model, device='cpu', quantize=True):
 def get_textbox(detector, image, canvas_size, mag_ratio, text_threshold, link_threshold, low_text, poly, device, optimal_num_chars=None):
     result = []
     estimate_num_chars = optimal_num_chars is not None
-    bboxes, polys = test_net(canvas_size, mag_ratio, detector, image, text_threshold, link_threshold, low_text, poly, device, estimate_num_chars)
-
+    bboxes_list, polys_list = test_net(canvas_size, mag_ratio, detector,
+                                       image, text_threshold,
+                                       link_threshold, low_text, poly,
+                                       device, estimate_num_chars)
     if estimate_num_chars:
-        polys = [p for p, _ in sorted(polys, key=lambda x: abs(optimal_num_chars - x[1]))]
+        polys_list = [[p for p, _ in sorted(polys, key=lambda x: abs(optimal_num_chars - x[1]))]
+                      for polys in polys_list]
 
-    for i, box in enumerate(polys):
-        poly = np.array(box).astype(np.int32).reshape((-1))
-        result.append(poly)
+    for polys in polys_list:
+        single_img_result = []
+        for i, box in enumerate(polys):
+            poly = np.array(box).astype(np.int32).reshape((-1))
+            single_img_result.append(poly)
+        result.append(single_img_result)
 
     return result

--- a/easyocr/utils.py
+++ b/easyocr/utils.py
@@ -703,6 +703,35 @@ def reformat_input(image):
     return img, img_cv_grey
 
 
+def reformat_input_batched(image, n_width=None, n_height=None):
+    """
+    reformats an image or list of images or a 4D numpy image array &
+    returns a list of corresponding img, img_cv_grey nd.arrays
+    image:
+        [file path, numpy-array, byte stream object,
+        list of file paths, list of numpy-array, 4D numpy array,
+        list of byte stream objects]
+    """
+    if ((isinstance(image, np.ndarray) and len(image.shape) == 4) or isinstance(image, list)):
+        # process image batches if image is list of image np arr, paths, bytes
+        img, img_cv_grey = [], []
+        for single_img in image:
+            clr, gry = reformat_input(single_img)
+            if n_width is not None and n_height is not None:
+                clr = cv2.resize(clr, (n_width, n_height))
+                gry = cv2.resize(gry, (n_width, n_height))
+            img.append(clr)
+            img_cv_grey.append(gry)
+        img, img_cv_grey = np.array(img), np.array(img_cv_grey)
+        # ragged tensors created when all input imgs are not of the same size
+        if len(img.shape) == 1 and len(img_cv_grey.shape) == 1:
+            raise ValueError("The input image array contains images of different sizes. " +
+                             "Please resize all images to same shape or pass n_width, n_height to auto-resize")
+    else:
+        img, img_cv_grey = reformat_input(image)
+    return img, img_cv_grey
+
+
 def make_rotated_img_list(rotationInfo, img_list):
     result_img_list = img_list[:]
 


### PR DESCRIPTION
# Batched image inference for text detection

```python
reader = easyocr.Reader(['en'], cudnn_benchmark=True)
img_path = [
        "https://pytorch.org/tutorials/_static/img/thumbnails/cropped/profiler.png",
        "https://www.tensorflow.org/images/tf_logo_social.png",
        "https://storage.googleapis.com/gd-wagtail-prod-assets/original_images/evolving_google_identity_2x1.jpg"]
reader.readtext_batched(img_path, n_width=800, n_height=600)
```
_Caveats:_
1.    For batched inference, all input images must be of the same size. They can be resized before or the `n_width` and `n_height` parameters can be used in `readtext_batched`. `readtext_batched` can also take a single image as input but returns a result list with one element, i.e. a further result[0] access will be required.
2.   `cudnn.benchmark` mode set to True is better for batched inference hence I pass `cudnn_benchmark=True` in `easyocr.Reader`
3.    **GPU batched inference needs some warmup for the same batch size to see better performance on batched mode** hence I use `dummy = np.zeros([batch_size, 600, 800, 3], dtype=np.uint8); reader.readtext_batched(dummy)`before timing the inferences.
4. Batched inference mode should be used when a large number of frames are needed to be processed i.e. detecting and recognizing text in a video, otherwise, sequential processing will be faster for processing one image per API call.
5. When running on GPU mode, the user will have to take care of the batch size themselves to prevent cuda out of memory error

## Edited files

These changes although major should have no backward compatibility issues, but I would greatly appreciate extensive testing @rkcosmos . I am open to any suggestions or changes

**utils.py**
-   Added a new function`reformat_input_batched` to take a list of file paths, numpy ndarrays, or byte stream objects 

 **detection.py**
-   Changed the `get_textbox` function to process a list of lists of bboxes and polys
-   Changed the `test_net` functions to accumulate the input image and send all the inputs in a single tensor to the CRAFT torch model

**easyocr.py**
-   Added a new function `readtext_batched` to take a list of file paths, numpy ndarrays, or byte stream objects now to process them in batch.
-   Change the `detect` function to process a list of images

I have a test script here to verify the functions are working as intended and added results for both CPU and GPU

As expected GPU batched inference is almost twice as fast as sequential GPU inference.

# GPU results

<img width="1376" alt="gpu" src="https://user-images.githubusercontent.com/13418507/121773484-56155d00-cb8d-11eb-92cb-d1353464237b.png">

# CPU results

<img width="1373" alt="cpu" src="https://user-images.githubusercontent.com/13418507/121773481-5150a900-cb8d-11eb-9fae-ec1e5598e777.png">

`test_batch_easyocr.py` program to generate the outputs above

```python
from __future__ import print_function

import easyocr
import numpy as np
import time
import cv2
import sys
import os

if sys.version_info[0] == 2:
    from six.moves.urllib.request import urlretrieve
else:
    from urllib.request import urlretrieve


def test_single_and_batched_text_detection_and_prediction():
    reader = easyocr.Reader(['en'])
    # test with easy logos to ensure same results
    # test for single image with old api
    result = reader.readtext(
        "https://pytorch.org/tutorials/_static/img/thumbnails/cropped/profiler.png")
    assert len(result), 1
    assert result[0][1], 'PyTorch'
    print(result)
    print("Single image test with readtext successful")

    # test for single image with new api
    result = reader.readtext_batched(
        "https://pytorch.org/tutorials/_static/img/thumbnails/cropped/profiler.png")
    assert len(result), 1
    assert result[0][0][1], 'PyTorch'
    print(result)
    print("Single image test with readtext_batched successful")

    # test for a list of images in batch
    img_path = [
        "https://pytorch.org/tutorials/_static/img/thumbnails/cropped/profiler.png",
        "https://www.tensorflow.org/images/tf_logo_social.png",
        "https://storage.googleapis.com/gd-wagtail-prod-assets/original_images/evolving_google_identity_2x1.jpg"]

    """
    all images in image list must be of the same size for batched inference
        for eg, result = reader.readtext_batched(img_path) will fail here
        so either resize all images to the same size before passing to readtext_batched
        or call the func like so reader.readtext_batched(img_path, n_width=800, n_height=600)
    """
    # warning, for better results, it is recommended to maintain aspect while resizing
    result = reader.readtext_batched(img_path, n_width=800, n_height=600)
    assert len(result), 3
    assert result[0][0][1], 'PyTorch'
    assert result[1][0][1], 'TensorFlow'
    assert result[2][0][1], 'Google'
    print(result)
    print("Batched image test with readtext_batched successful")

    ############################################################################
    # inference time test between sequential and batch processing
    # batch processing will be faster when using GPU
    ############################################################################
    # pre-download, load and resize images for inference time test
    img_path = [
        "https://pytorch.org/tutorials/_static/img/thumbnails/cropped/profiler.png",
        "https://www.tensorflow.org/images/tf_logo_social.png",
        "https://storage.googleapis.com/gd-wagtail-prod-assets/original_images/evolving_google_identity_2x1.jpg"]

    cv2_images = []
    for i, path in enumerate(img_path):
        tmp, _ = urlretrieve(path)
        cv2_img = cv2.resize(cv2.imread(tmp), (800, 600))
        cv2_images.append(cv2_img)
        os.remove(tmp)

    img_repeat, num_loop = 5, 1
    cv2_images = np.array(cv2_images)
    # np repeat to get a batch of 15 images, getting arr 15,600,800,3
    cv2_images_repeat1 = np.repeat(cv2_images, repeats=img_repeat, axis=0)
    cv2_images_repeat2 = cv2_images_repeat1.copy()
    print(
        f"Running inference speed test with an image array of shape {cv2_images_repeat1.shape} for {num_loop} iterations")

    # sequential processing
    # run batch processing test
    reader = easyocr.Reader(['en'])
    itime = time.time()
    for i in range(num_loop):
        for img in cv2_images_repeat1:
            reader.readtext(img)
    print(
        "Single/Sequential image inference time per image: " +
        f"{(time.time()-itime)/(num_loop*cv2_images_repeat1.shape[0]):.3f}s")
    # batched processing
    reader = easyocr.Reader(['en'], cudnn_benchmark=True)

    # warmup for batched inference on GPU, using same batch size for all subsequent inference
    # cudnn benchmark should be set to True
    # see this issue https://discuss.pytorch.org/t/model-inference-very-slow-when-batch-size-changes-for-the-first-time/44911
    dummy = np.zeros([len(img_path) * img_repeat, 600, 800, 3], dtype=np.uint8)
    reader.readtext_batched(dummy)

    # run batch processing test
    itime = time.time()
    for i in range(num_loop):
        reader.readtext_batched(cv2_images_repeat2)
    print(
        "Batched image inference time per image: " +
        f"{(time.time()-itime)/(num_loop*cv2_images_repeat1.shape[0]):.3f}s")


test_single_and_batched_text_detection_and_prediction()

```