### PR TITLE
Fix onnx export issue when gpu is avai

### DIFF
--- a/easyocr/export.py
+++ b/easyocr/export.py
@@ -19,8 +19,8 @@ def export_detector(detector_onnx_save_path,
                     recognizer=True):
     if dynamic is False:
         print('WARNING: it is recommended to use -d dynamic flag when exporting onnx')
-
     ocr_reader = easyocr.Reader(lang_list,
+                                gpu=False if device == "cpu" else True,
                                 detector=detector,
                                 recognizer=detector,
                                 quantize=quantize,
@@ -72,15 +72,15 @@ def export_detector(detector_onnx_save_path,
         ort_inputs = {ort_session.get_inputs()[0].name: to_numpy(dummy_input)}
         y_onnx_out, feature_onnx_out = ort_session.run(None, ort_inputs)
 
-        print("torch output shapes", y_torch_out.shape, feature_torch_out.shape)
-        print("onnx output shapes", y_onnx_out.shape, feature_onnx_out.shape)
+        print(f"torch outputs: y_torch_out.shape={y_torch_out.shape} feature_torch_out.shape={feature_torch_out.shape}")
+        print(f"onnx outputs: y_onnx_out.shape={y_onnx_out.shape} feature_onnx_out.shape={feature_onnx_out.shape}")
         # compare ONNX Runtime and PyTorch results
         np.testing.assert_allclose(
             to_numpy(y_torch_out), y_onnx_out, rtol=1e-03, atol=1e-05)
         np.testing.assert_allclose(
             to_numpy(feature_torch_out), feature_onnx_out, rtol=1e-03, atol=1e-05)
 
-        print("Exported model has been tested with ONNXRuntime, and the result looks good!")
+        print(f"Model exported to {detector_onnx_save_path} and tested with ONNXRuntime, and the result looks good!")
 
 
 def parse_args():


### PR DESCRIPTION
Fixed issue where easyocr detector was being loaded in gpu by default before onnx export.

onnx export does not work with the model in data parallel mode so the model must be exported to onnx in CPU mode even when gpus are avai.