### PR TITLE
Using opencv-python-headless in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 torch
 torchvision>=0.5
-opencv-python
+opencv-python-headless
 scipy
 numpy
 Pillow<8.3.0


### PR DESCRIPTION
Replace `opencv-python` in `requirements.txt` with headless version for smooth deployment in servers and containers.

See also issue #485.