### PR TITLE
Fix rotation tta best result selection

### DIFF
--- a/easyocr/easyocr.py
+++ b/easyocr/easyocr.py
@@ -348,7 +348,10 @@ class Reader(object):
                           workers, self.device)
 
             if rotation_info and (horizontal_list+free_list):
-                result = set_result_with_confidence(result, image_len)
+                # Reshape result to be a list of lists, each row being for 
+                # one of the rotations (first row being no rotation)
+                result = set_result_with_confidence(
+                    [result[image_len*i:image_len*(i+1)] for i in range(len(rotation_info) + 1)])
 
         if self.model_lang == 'arabic':
             direction_mode = 'rtl'

--- a/easyocr/utils.py
+++ b/easyocr/utils.py
@@ -774,35 +774,20 @@ def make_rotated_img_list(rotationInfo, img_list):
     return result_img_list
 
 
-def set_result_with_confidence(result_list, origin_len):
-    
-    set_len = len(result_list)//origin_len
-
-    k = 0
-    result_to_split  =  [[] for i in range(set_len)] # list having the same length of the rotation_info list : each element is a list of rotated images in the same direction  
-    
-    # fill
-    for i in range(set_len):
-        tmp_list = []
-        for j in range(origin_len):
-            tmp_list.append(result_list[k])
-            k += 1
-        result_to_split[i] += tmp_list
-
-
-    
-    
-    ## choose the best result from different rotations
-    
+def set_result_with_confidence(results):
+    """ Select highest confidence augmentation for TTA
+    Given a list of lists of results (outer list has one list per augmentation,
+    inner lists index the images being recognized), choose the best result 
+    according to confidence level.
+    Each "result" is of the form (box coords, text, confidence)
+    A final_result is returned which contains one result for each image
+    """
     final_result = []
-    for i in range(origin_len): 
-        result = result_to_split[0][i] # format : ([[,],[,],[,],[,]], 'string', confidnece)
-        confidence = result_to_split[0][i][2]
-        for rot in range (1,set_len):
-            if (result_to_split[rot] and len(result_to_split[rot][i][1]) >= len(result[1])):
-                result = result_to_split[rot][i]
-                confidence =  result_to_split[rot][i][2]
-
-        final_result.append(result)
+    for col_ix in range(len(results[0])):
+        # Take the row_ix associated with the max confidence
+        best_row = max(
+            [(row_ix, results[row_ix][col_ix][2]) for row_ix in range(len(results))],
+            key=lambda x: x[1])[0]
+        final_result.append(results[best_row][col_ix])
 
     return final_result


### PR DESCRIPTION
I believe the prior implementation of `set_result_with_confidence` doesn't do what the docs say with regards to the `rotation_info` kwarg

> Allow EasyOCR to rotate each text box and return the one with the best confident score.

In fact it seems to be simply selecting the longest string, not the most confident. See this line: https://github.com/JaidedAI/EasyOCR/blob/c471b1ce1ceb0aba3cb59463083c7e6f8a86b098/easyocr/utils.py#L802

So this PR addresses that, ie I rewrote `set_result_with_confidence` to indeed select the result with the highest confidence.

Happy for maintainers to edit my PR. Just note that the prior version has a check on whether a result exists (see that line I linked above - `if result_to_split[rot]`). I dropped this because I couldn't see why it was necessary - but feel free to pop it back in if there's a reason to keep it.