### PR TITLE
Fixes a bug of the progress bar, and improves `.gitignore`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@ ENV/
 # macOS
 *.DS_Store
 
-#virtual env
- .vscode/
- .vs/
+# IDEs
+.vscode/
+.vs/
+.idea/

--- a/easyocr/utils.py
+++ b/easyocr/utils.py
@@ -667,7 +667,7 @@ def get_paragraph(raw_result, x_ths=1, y_ths=0.5, mode = 'ltr'):
     return result
 
 
-def printProgressBar (prefix = '', suffix = '', decimals = 1, length = 100, fill = '█', printEnd = "\r"):
+def printProgressBar(prefix='', suffix='', decimals=1, length=100, fill='█'):
     """
     Call in a loop to create terminal progress bar
     @params:
@@ -683,7 +683,7 @@ def printProgressBar (prefix = '', suffix = '', decimals = 1, length = 100, fill
         percent = ("{0:." + str(decimals) + "f}").format(progress * 100)
         filledLength = int(length * progress)
         bar = fill * filledLength + '-' * (length - filledLength)
-        print(f'\r{prefix} |{bar}| {percent}% {suffix}', end = printEnd)
+        print(f'\r{prefix} |{bar}| {percent}% {suffix}', end='')
 
     return progress_hook
 


### PR DESCRIPTION
The original progress bar prints a '\r' at first, but it prints another '\r' just after the progress is printed, which makes the bar flicker. Since the progress bar is only used when downloading the model, the trailing '\r' is useless and is removed, so that it should not flicker when downloading.