### PR TITLE
Fix wrong parameter type for `setModelLanguage`

### DIFF
--- a/easyocr/easyocr.py
+++ b/easyocr/easyocr.py
@@ -204,7 +204,7 @@ class Reader(object):
                 recog_config = yaml.load(file, Loader=yaml.FullLoader)
             imgH = recog_config['imgH']
             available_lang = recog_config['lang_list']
-            self.setModelLanguage(recog_network, lang_list, available_lang, available_lang)
+            self.setModelLanguage(recog_network, lang_list, available_lang, str(available_lang))
             #char_file = os.path.join(self.user_network_directory, recog_network+ '.txt')
             self.character = recog_config['character_list']
             model_file = recog_network+ '.pth'


### PR DESCRIPTION
`setModelLanguage` accepts string expression of `list` as a `list_lang_string`. But when using user-defined model it passes a list to method directly. This cause that the Python interpreter can not reveal what is really wrong, showing TypeError.

And is there any reason that not using `str()` for `list_lang_string` of `setModelLanguage`? I think `list_lang_string` can be derived from `str(list_lang)`