### PR TITLE
Higher version of opencv-python-headless will cause a bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 torch
 torchvision>=0.5
-opencv-python-headless<=4.5.4.60
+opencv-python-headless==4.5.1.48
 scipy
 numpy
 Pillow


### PR DESCRIPTION
detail can be seen in issue 640:
[https://github.com/JaidedAI/EasyOCR/issues/640](url)

This problem can be solved by lower the version of  opencv-python-headless