### PR TITLE
Higher version of opencv-python-headless may not work well in some OS.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 torch
 torchvision>=0.5
-opencv-python-headless<=4.5.4.60
+opencv-python-headless==4.5.1.48
 scipy
 numpy
 Pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 torch
 torchvision>=0.5
-opencv-python-headless==4.5.1.48
+opencv-python-headless<=4.5.1.48
 scipy
 numpy
 Pillow


### PR DESCRIPTION
Higher version of opencv-python-headless may not work well in some OS.
At least 4 people have experienced this problem.

detail can be seen in issue 640:
https://github.com/JaidedAI/EasyOCR/issues/640

This problem can be solved by lower the version of opencv-python-headless