### PR TITLE
Feature: Use non-listed symbols for custom model

### DIFF
--- a/easyocr/easyocr.py
+++ b/easyocr/easyocr.py
@@ -213,7 +213,7 @@ class Reader(object):
             self.character = recog_config['character_list']
             model_file = recog_network+ '.pth'
             model_path = os.path.join(self.model_storage_directory, model_file)
-            self.setLanguageList(lang_list, None)
+            self.setLanguageList(lang_list, recog_config)
 
         dict_list = {}
         for lang in lang_list:
@@ -261,8 +261,10 @@ class Reader(object):
             with open(char_file, "r", encoding = "utf-8-sig") as input_file:
                 char_list =  input_file.read().splitlines()
             self.lang_char += char_list
-        if model:
+        if model.get('symbols'):
             symbol = model['symbols']
+        elif model.get('character_list'):
+            symbol = model['character_list']
         else:
             symbol = '0123456789!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~ '
         self.lang_char = set(self.lang_char).union(set(symbol))


### PR DESCRIPTION
It appeared that when using a custom model, language symbol list is made from language characters and explicitly stated **symbol** string, so all symbols that are not listed in **symbol** string are being put to **ignore_char**. 

This led to the problem, that adding some special characters as © (copyright sign) to the custom model config file resulted in skipping this character on evaluation and excluding images with this character from the data loader on train.

That is why a possibility for a custom model to use **character_list** from its config file instead of predefined list of symbols was added.