### PR TITLE
docs: Fix a few typos

### DIFF
--- a/trainer/craft/metrics/eval_det_iou.py
+++ b/trainer/craft/metrics/eval_det_iou.py
@@ -136,7 +136,7 @@ class DetectionIoUEvaluator(object):
             if len(detDontCarePolsNum) > 0 else "\n")
 
         if len(gtPols) > 0 and len(detPols) > 0:
-            # Calculate IoU and precision matrixs
+            # Calculate IoU and precision matrices
             outputShape = [len(gtPols), len(detPols)]
             iouMat = np.empty(outputShape)
             gtRectMat = np.zeros(len(gtPols), np.int8)

--- a/trainer/craft/utils/inference_boxes.py
+++ b/trainer/craft/utils/inference_boxes.py
@@ -251,7 +251,7 @@ def load_icdar2015_gt(dataFolder, isTraing=False):
 
 def load_icdar2013_gt(dataFolder, isTraing=False):
 
-    # choise test dataset
+    # choose test dataset
     if isTraing:
         img_folderName = "Challenge2_Test_Task12_Images"
         gt_folderName = "Challenge2_Test_Task1_GT"

--- a/trainer/modules/transformation.py
+++ b/trainer/modules/transformation.py
@@ -80,7 +80,7 @@ class LocalizationNetwork(nn.Module):
 
 
 class GridGenerator(nn.Module):
-    """ Grid Generator of RARE, which produces P_prime by multipling T with P """
+    """ Grid Generator of RARE, which produces P_prime by multiplying T with P """
 
     def __init__(self, F, I_r_size):
         """ Generate P_hat and inv_delta_C for later """

--- a/trainer/test.py
+++ b/trainer/test.py
@@ -37,7 +37,7 @@ def validation(model, criterion, evaluation_loader, converter, opt, device):
             preds = model(image, text_for_pred)
             forward_time = time.time() - start_time
 
-            # Calculate evaluation loss for CTC deocder.
+            # Calculate evaluation loss for CTC decoder.
             preds_size = torch.IntTensor([preds.size(1)] * batch_size)
             # permute 'preds' to use CTCloss format
             cost = criterion(preds.log_softmax(2).permute(1, 0, 2), text_for_loss, preds_size, length_for_loss)


### PR DESCRIPTION
There are small typos in:
- trainer/craft/metrics/eval_det_iou.py
- trainer/craft/utils/inference_boxes.py
- trainer/modules/transformation.py
- trainer/test.py

Fixes:
- Should read `multiplying` rather than `multipling`.
- Should read `matrices` rather than `matrixs`.
- Should read `decoder` rather than `deocder`.
- Should read `choose` rather than `choise`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md