### PR TITLE
Modify model classes to allow serialization and optimization with TorchScript

### DIFF
--- a/easyocr/model/modules.py
+++ b/easyocr/model/modules.py
@@ -81,14 +81,6 @@ class BidirectionalLSTM(nn.Module):
         self.linear = nn.Linear(hidden_size * 2, output_size)
 
     def forward(self, input):
-        """
-        input : visual feature [batch_size x T x input_size]
-        output : contextual feature [batch_size x T x output_size]
-        """
-        try: # multi gpu needs this
-            self.rnn.flatten_parameters()
-        except: # quantization doesn't work with this 
-            pass
         recurrent, _ = self.rnn(input)  # batch_size x T x input_size -> batch_size x T x (2*hidden_size)
         output = self.linear(recurrent)  # batch_size x T x output_size
         return output
@@ -118,6 +110,7 @@ class VGG_FeatureExtractor(nn.Module):
     def forward(self, input):
         return self.ConvNet(input)
 
+
 class ResNet_FeatureExtractor(nn.Module):
     """ FeatureExtractor of FAN (http://openaccess.thecvf.com/content_ICCV_2017/papers/Cheng_Focusing_Attention_Towards_ICCV_2017_paper.pdf) """
 
@@ -127,6 +120,7 @@ class ResNet_FeatureExtractor(nn.Module):
 
     def forward(self, input):
         return self.ConvNet(input)
+
 
 class BasicBlock(nn.Module):
     expansion = 1
@@ -158,10 +152,12 @@ class BasicBlock(nn.Module):
 
         if self.downsample is not None:
             residual = self.downsample(x)
+
         out += residual
         out = self.relu(out)
 
         return out
+
 
 class ResNet(nn.Module):
 

--- a/easyocr/model/modules.py
+++ b/easyocr/model/modules.py
@@ -68,9 +68,9 @@ class vgg16_bn(torch.nn.Module):
         h_relu5_3 = h
         h = self.slice5(h)
         h_fc7 = h
-        vgg_outputs = namedtuple("VggOutputs", ['fc7', 'relu5_3', 'relu4_3', 'relu3_2', 'relu2_2'])
-        out = vgg_outputs(h_fc7, h_relu5_3, h_relu4_3, h_relu3_2, h_relu2_2)
-        return out
+
+        return h_fc7, h_relu5_3, h_relu4_3, h_relu3_2, h_relu2_2
+
 
 class BidirectionalLSTM(nn.Module):
 
@@ -91,6 +91,7 @@ class BidirectionalLSTM(nn.Module):
         recurrent, _ = self.rnn(input)  # batch_size x T x input_size -> batch_size x T x (2*hidden_size)
         output = self.linear(recurrent)  # batch_size x T x output_size
         return output
+
 
 class VGG_FeatureExtractor(nn.Module):
 

--- a/easyocr/model/modules.py
+++ b/easyocr/model/modules.py
@@ -1,10 +1,10 @@
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 import torch.nn.init as init
+
 from torchvision import models
 from torchvision.models.vgg import model_urls
-from collections import namedtuple
+
 
 def init_weights(modules):
     for m in modules:
@@ -18,6 +18,7 @@ def init_weights(modules):
         elif isinstance(m, nn.Linear):
             m.weight.data.normal_(0, 0.01)
             m.bias.data.zero_()
+
 
 class vgg16_bn(torch.nn.Module):
     def __init__(self, pretrained=True, freeze=True):

--- a/easyocr/model/vgg_model.py
+++ b/easyocr/model/vgg_model.py
@@ -1,35 +1,27 @@
+import torch
 import torch.nn as nn
 from .modules import VGG_FeatureExtractor, BidirectionalLSTM
 
-class Model(nn.Module):
 
+class Model(nn.Module):
     def __init__(self, input_channel, output_channel, hidden_size, num_class):
         super(Model, self).__init__()
-        """ FeatureExtraction """
         self.FeatureExtraction = VGG_FeatureExtractor(input_channel, output_channel)
         self.FeatureExtraction_output = output_channel
-        self.AdaptiveAvgPool = nn.AdaptiveAvgPool2d((None, 1))
 
-        """ Sequence modeling"""
         self.SequenceModeling = nn.Sequential(
             BidirectionalLSTM(self.FeatureExtraction_output, hidden_size, hidden_size),
             BidirectionalLSTM(hidden_size, hidden_size, hidden_size))
         self.SequenceModeling_output = hidden_size
 
-        """ Prediction """
         self.Prediction = nn.Linear(self.SequenceModeling_output, num_class)
 
-
     def forward(self, input, text):
-        """ Feature extraction stage """
         visual_feature = self.FeatureExtraction(input)
-        visual_feature = self.AdaptiveAvgPool(visual_feature.permute(0, 3, 1, 2))
-        visual_feature = visual_feature.squeeze(3)
+        visual_feature = torch.mean(visual_feature.permute(0, 3, 1, 2), dim=3)
 
-        """ Sequence modeling stage """
         contextual_feature = self.SequenceModeling(visual_feature)
 
-        """ Prediction stage """
         prediction = self.Prediction(contextual_feature.contiguous())
 
         return prediction

--- a/easyocr/recognition.py
+++ b/easyocr/recognition.py
@@ -1,22 +1,30 @@
-from PIL import Image
+import importlib
+import math
+import types
+
+from collections import OrderedDict
+
 import torch
-import torch.backends.cudnn as cudnn
-import torch.utils.data
 import torch.nn.functional as F
+import torch.utils.data
 import torchvision.transforms as transforms
 import numpy as np
-from collections import OrderedDict
-import importlib
+
+from PIL import Image
+
+from .model.modules import BidirectionalLSTM
 from .utils import CTCLabelConverter
-import math
+
 
 def custom_mean(x):
     return x.prod()**(2.0/np.sqrt(len(x)))
+
 
 def contrast_grey(img):
     high = np.percentile(img, 90)
     low  = np.percentile(img, 10)
     return (high-low)/np.maximum(10, high+low), high, low
+
 
 def adjust_contrast_grey(img, target = 0.4):
     contrast, high, low = contrast_grey(img)
@@ -27,8 +35,8 @@ def adjust_contrast_grey(img, target = 0.4):
         img = np.maximum(np.full(img.shape, 0) ,np.minimum(np.full(img.shape, 255), img)).astype(np.uint8)
     return img
 
-class NormalizePAD(object):
 
+class NormalizePAD(object):
     def __init__(self, max_size, PAD_type='right'):
         self.toTensor = transforms.ToTensor()
         self.max_size = max_size
@@ -46,8 +54,8 @@ class NormalizePAD(object):
 
         return Pad_img
 
-class ListDataset(torch.utils.data.Dataset):
 
+class ListDataset(torch.utils.data.Dataset):
     def __init__(self, image_list):
         self.image_list = image_list
         self.nSamples = len(image_list)
@@ -59,8 +67,8 @@ class ListDataset(torch.utils.data.Dataset):
         img = self.image_list[index]
         return Image.fromarray(img, 'L')
 
-class AlignCollate(object):
 
+class AlignCollate(object):
     def __init__(self, imgH=32, imgW=100, keep_ratio_with_pad=False, adjust_contrast = 0.):
         self.imgH = imgH
         self.imgW = imgW
@@ -96,8 +104,9 @@ class AlignCollate(object):
         image_tensors = torch.cat([t.unsqueeze(0) for t in resized_images], 0)
         return image_tensors
 
-def recognizer_predict(model, converter, test_loader, batch_max_length,\
-                       ignore_idx, char_group_idx, decoder = 'greedy', beamWidth= 5, device = 'cpu'):
+
+def recognizer_predict(model, converter, test_loader, batch_max_length,
+                       ignore_idx, char_group_idx, decoder='greedy', beamWidth=5, device='cpu'):
     model.eval()
     result = []
     with torch.no_grad():
@@ -150,9 +159,10 @@ def recognizer_predict(model, converter, test_loader, batch_max_length,\
 
     return result
 
-def get_recognizer(recog_network, network_params, character,\
-                   separator_list, dict_list, model_path,\
-                   device = 'cpu', quantize = True):
+
+def get_recognizer(recog_network, network_params, character,
+                   separator_list, dict_list, model_path,
+                   device='cpu', quantize=True):
 
     converter = CTCLabelConverter(character, separator_list, dict_list)
     num_class = len(converter.character)
@@ -178,10 +188,21 @@ def get_recognizer(recog_network, network_params, character,\
             except:
                 pass
     else:
+        # Override the forward method to flatten parameters when in a multi-GPU environment
+        def dp_forward(self, input):
+            self.rnn.flatten_parameters()
+            return self.forward_(input)
+
+        for m in model.modules():
+            if type(m) is BidirectionalLSTM:
+                m.forward_ = m.forward
+                m.forward = types.MethodType(dp_forward, m)
+
         model = torch.nn.DataParallel(model).to(device)
         model.load_state_dict(torch.load(model_path, map_location=device))
 
     return model, converter
+
 
 def get_text(character, imgH, imgW, recognizer, converter, image_list,\
              ignore_char = '',decoder = 'greedy', beamWidth =5, batch_size=1, contrast_ths=0.1,\

--- a/trainer/craft/model/vgg16_bn.py
+++ b/trainer/craft/model/vgg16_bn.py
@@ -1,10 +1,10 @@
-from collections import namedtuple
-
 import torch
 import torch.nn as nn
 import torch.nn.init as init
+
 from torchvision import models
 from torchvision.models.vgg import model_urls
+
 
 def init_weights(modules):
     for m in modules:
@@ -18,6 +18,7 @@ def init_weights(modules):
         elif isinstance(m, nn.Linear):
             m.weight.data.normal_(0, 0.01)
             m.bias.data.zero_()
+
 
 class vgg16_bn(torch.nn.Module):
     def __init__(self, pretrained=True, freeze=True):

--- a/trainer/craft/model/vgg16_bn.py
+++ b/trainer/craft/model/vgg16_bn.py
@@ -68,6 +68,4 @@ class vgg16_bn(torch.nn.Module):
         h_relu5_3 = h
         h = self.slice5(h)
         h_fc7 = h
-        vgg_outputs = namedtuple("VggOutputs", ['fc7', 'relu5_3', 'relu4_3', 'relu3_2', 'relu2_2'])
-        out = vgg_outputs(h_fc7, h_relu5_3, h_relu4_3, h_relu3_2, h_relu2_2)
-        return out
+        return h_fc7, h_relu5_3, h_relu4_3, h_relu3_2, h_relu2_2


### PR DESCRIPTION
The model class definitions had minor issues that prevented compilation with `torch.jit.script`:

* `vgg16_bn` used `namedtuple` in `forward`
  * No features of `namedtuple` were actually being used, so now returns a regular tuple
* `BidirectionLSTM` used a `try`/`except` in `forward`
  * Instead of try/except there, added a method override in `get_recognizer` when GPU is enabled to inject the `rnn.flatten_parameters()` call
* `torch.jit.script` does not support `nn.AdaptiveAvgPool2d` with `None` dims
  * Replaced with `torch.mean(x, dim=3)`, which is equivalent at the relevant line

Other edits are just import ordering / dead import removes, line breaks, etc.

Using `torch.jit.script` and `torch.jit.optimize_for_inference` allowed me to run models about 14% faster on CPU in [Colab](https://colab.research.google.com/drive/1Nw5YdvaDWXuWlZjgjiys5PS80lsV4KCS?usp=sharing).