### PR TITLE
Update deprecated pretrained parameter

### DIFF
--- a/easyocr/model/modules.py
+++ b/easyocr/model/modules.py
@@ -3,6 +3,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.nn.init as init
 from torchvision import models
+from torchvision.models import VGG16_BN_Weights
 from torchvision.models.vgg import model_urls
 from collections import namedtuple
 
@@ -23,7 +24,9 @@ class vgg16_bn(torch.nn.Module):
     def __init__(self, pretrained=True, freeze=True):
         super(vgg16_bn, self).__init__()
         model_urls['vgg16_bn'] = model_urls['vgg16_bn'].replace('https://', 'http://')
-        vgg_pretrained_features = models.vgg16_bn(pretrained=pretrained).features
+        vgg_pretrained_features = models.vgg16_bn(
+            weights=VGG16_BN_Weights.DEFAULT if pretrained else None
+        ).features
         self.slice1 = torch.nn.Sequential()
         self.slice2 = torch.nn.Sequential()
         self.slice3 = torch.nn.Sequential()

--- a/trainer/craft/model/vgg16_bn.py
+++ b/trainer/craft/model/vgg16_bn.py
@@ -3,6 +3,7 @@ import torch.nn as nn
 import torch.nn.init as init
 
 from torchvision import models
+from torchvision.models import VGG16_BN_Weights
 from torchvision.models.vgg import model_urls
 
 
@@ -24,7 +25,9 @@ class vgg16_bn(torch.nn.Module):
     def __init__(self, pretrained=True, freeze=True):
         super(vgg16_bn, self).__init__()
         model_urls['vgg16_bn'] = model_urls['vgg16_bn'].replace('https://', 'http://')
-        vgg_pretrained_features = models.vgg16_bn(pretrained=pretrained).features
+        vgg_pretrained_features = models.vgg16_bn(
+            weights=VGG16_BN_Weights.DEFAULT if pretrained else None
+        ).features
         self.slice1 = torch.nn.Sequential()
         self.slice2 = torch.nn.Sequential()
         self.slice3 = torch.nn.Sequential()


### PR DESCRIPTION
Updating the `pretrained` parameter to remove the UserWarnings from PyTorch as discussed in https://github.com/JaidedAI/EasyOCR/issues/766. That fixed the warnings for the example that was provided, and there were no other use of that parameter when I grepped in the repo.