### PR TITLE
Fix setuptools warning in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
When building the project via `python setup.py build`, I get this warning from `dist.py`:

```sh
/usr/lib/python3.10/site-packages/setuptools/dist.py:757: UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead
```

This patch changes `description-file` to `description_file`, fixing that warning.