### PR TITLE
Dockerfile: Specify container registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM pytorch/pytorch
+FROM docker.io/pytorch/pytorch
 
 # if you forked EasyOCR, you can pass in your own GitHub username to use your fork
 # i.e. gh_username=myname


### PR DESCRIPTION
Allows the container to be built with e.g. podman without additional configuration.