### PR TITLE
Fix DBNet for numpy >= 1.20.0

### DIFF
--- a/easyocr/DBNet/DBNet.py
+++ b/easyocr/DBNet/DBNet.py
@@ -670,10 +670,10 @@ class DBNet:
         '''
         h, w = hmap.shape[:2]
         box = box_.copy()
-        xmin = np.clip(np.floor(box[:, 0].min()).astype(np.int), 0, w - 1)
-        xmax = np.clip(np.ceil(box[:, 0].max()).astype(np.int), 0, w - 1)
-        ymin = np.clip(np.floor(box[:, 1].min()).astype(np.int), 0, h - 1)
-        ymax = np.clip(np.ceil(box[:, 1].max()).astype(np.int), 0, h - 1)
+        xmin = np.clip(np.floor(box[:, 0].min()).astype(np.int32), 0, w - 1)
+        xmax = np.clip(np.ceil(box[:, 0].max()).astype(np.int32), 0, w - 1)
+        ymin = np.clip(np.floor(box[:, 1].min()).astype(np.int32), 0, h - 1)
+        ymax = np.clip(np.ceil(box[:, 1].max()).astype(np.int32), 0, h - 1)
     
         mask = np.zeros((ymax - ymin + 1, xmax - xmin + 1), dtype=np.uint8)
         box[:, 0] = box[:, 0] - xmin


### PR DESCRIPTION
Alias np.int has been deprecated and will result in an error: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations