### PR TITLE
adding get_text_coordinates to the reader object

### DIFF
--- a/easyocr/easyocr.py
+++ b/easyocr/easyocr.py
@@ -468,6 +468,38 @@ class Reader(object):
                                 filter_ths, y_ths, x_ths, False, output_format)
 
         return result
+
+    def get_text_coordinates(self, image, decoder = 'greedy', beamWidth= 5, batch_size = 1,\
+                 workers = 0, allowlist = None, blocklist = None, detail = 1,\
+                 rotation_info = None, paragraph = False, min_size = 20,\
+                 contrast_ths = 0.1,adjust_contrast = 0.5, filter_ths = 0.003,\
+                 text_threshold = 0.7, low_text = 0.4, link_threshold = 0.4,\
+                 canvas_size = 2560, mag_ratio = 1.,\
+                 slope_ths = 0.1, ycenter_ths = 0.5, height_ths = 0.5,\
+                 width_ths = 0.5, y_ths = 0.5, x_ths = 1.0, add_margin = 0.1, 
+                 threshold = 0.2, bbox_min_score = 0.2, bbox_min_size = 3, max_candidates = 0,
+                 output_format='standard'):
+        
+        '''
+        Parameters:
+        image: file path or numpy-array or a byte stream object
+        '''
+        img, img_cv_grey = reformat_input(image)
+
+        horizontal_list, free_list = self.detect(img, 
+                                                 min_size = min_size, text_threshold = text_threshold,\
+                                                 low_text = low_text, link_threshold = link_threshold,\
+                                                 canvas_size = canvas_size, mag_ratio = mag_ratio,\
+                                                 slope_ths = slope_ths, ycenter_ths = ycenter_ths,\
+                                                 height_ths = height_ths, width_ths= width_ths,\
+                                                 add_margin = add_margin, reformat = False,\
+                                                 threshold = threshold, bbox_min_score = bbox_min_score,\
+                                                 bbox_min_size = bbox_min_size, max_candidates = max_candidates
+                                                 )
+        # get the 1st result from hor & free list as self.detect returns a list of depth 3
+        horizontal_list, free_list = horizontal_list[0], free_list[0]
+        return horizontal_list, free_list
+
     
     def readtextlang(self, image, decoder = 'greedy', beamWidth= 5, batch_size = 1,\
                  workers = 0, allowlist = None, blocklist = None, detail = 1,\


### PR DESCRIPTION
Adding a function get_text_coordinates to the Reader object. There might be cases where the user only wants to use the detector. One example of such a case could be when you want to filter out images with text detected in them from an image dataset. 