### PR TITLE
cli fix - rotation_info type cast error

### DIFF
--- a/easyocr/cli.py
+++ b/easyocr/cli.py
@@ -1,6 +1,8 @@
 import argparse
 import easyocr
 
+def list_of_ints(arg):
+    return list(map(int, arg.split(',')))
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Process EasyOCR.")
@@ -125,7 +127,7 @@ def parse_args():
     )
     parser.add_argument(
         "--rotation_info",
-        type=list,
+        type=list_of_ints,
         default=None,
         help="Allow EasyOCR to rotate each text box and return the one with the best confident score. Eligible values are 90, 180 and 270. For example, try [90, 180 ,270] for all possible text orientations.",
     )


### PR DESCRIPTION
Rotation angles were treated as strings. 

Caused this type cast error:

```
Traceback (most recent call last):
  File "python3\lib\runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "python3\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "Python3\Scripts\easyocr.exe\__main__.py", line 7, in <module>
  File "python3\lib\site-packages\easyocr\cli.py", line 253, in main
    for line in reader.readtext(args.file,\
  File "python3\lib\site-packages\easyocr\easyocr.py", line 468, in readtext
    result = self.recognize(img_cv_grey, horizontal_list, free_list,\
  File "python3\lib\site-packages\easyocr\easyocr.py", line 401, in recognize
    image_list = make_rotated_img_list(rotation_info, image_list)
  File "python3\lib\site-packages\easyocr\utils.py", line 814, in make_rotated_img_list
    rotated = ndimage.rotate(img_info[1], angle, reshape=True)
  File "python3\lib\site-packages\scipy\ndimage\_interpolation.py", line 913, in rotate
    c, s = special.cosdg(angle), special.sindg(angle)
TypeError: ufunc 'cosdg' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''
```