### PR TITLE
Update Dockerfile - noninteractive mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM docker.io/pytorch/pytorch
 
+# to disable interactive mode: https://askubuntu.com/questions/909277/avoiding-user-interaction-with-tzdata-when-installing-certbot-in-a-docker-contai
+ENV DEBIAN_FRONTEND=noninteractive
+
 # if you forked EasyOCR, you can pass in your own GitHub username to use your fork
 # i.e. gh_username=myname
 ARG gh_username=JaidedAI


### PR DESCRIPTION
Building this Dockerfile will result in the interactive prompt
```
 => [2/4] RUN apt-get update -y &&     apt-get install -y     libglib2.0-0     libsm6     libxext6     libxrender-dev     libgl1-mesa-dev     git     && apt-get autoremove -y     && apt-get clean -y     && r  266.2s
 => => # questions will narrow this down by presenting a list of cities, representing                                                                                                                                  
 => => # the time zones in which they are located.                                                                                                                                                                     
 => => #   1. Africa      4. Australia  7. Atlantic  10. Pacific  13. Etc                                                                                                                                              
 => => #   2. America     5. Arctic     8. Europe    11. SystemV                                                                                                                                                       
 => => #   3. Antarctica  6. Asia       9. Indian    12. US                                                                                                                                                            
 => => # Geographic area:  
```

which user will not be able to answer.

Here is PR with working proposition to fix it