### PR TITLE
Add hOCR output format

### DIFF
--- a/easyocr/cli.py
+++ b/easyocr/cli.py
@@ -229,7 +229,7 @@ def parse_args():
     parser.add_argument(
         "--output_format",
         type=str,
-        choices=["standard", 'dict', 'json'],
+        choices=["standard", 'dict', 'json', "hocr"],
         default='standard',
         help="output format.",
     )

--- a/easyocr/easyocr.py
+++ b/easyocr/easyocr.py
@@ -4,7 +4,7 @@ from .recognition import get_recognizer, get_text
 from .utils import group_text_box, get_image_list, calculate_md5, get_paragraph,\
                    download_and_unzip, printProgressBar, diff, reformat_input,\
                    make_rotated_img_list, set_result_with_confidence,\
-                   reformat_input_batched, merge_to_free
+                   reformat_input_batched, merge_to_free, to_hocr
 from .config import *
 from bidi.algorithm import get_display
 import numpy as np
@@ -434,6 +434,8 @@ class Reader(object):
             return [json.dumps({'boxes':[list(map(int, lst)) for lst in item[0]],'text':item[1],'confident':item[2]}, ensure_ascii=False) for item in result]
         elif output_format == 'free_merge':
             return merge_to_free(result, free_list)
+        elif output_format == "hocr":
+            return to_hocr(result)
         else:
             return result
 


### PR DESCRIPTION
This change adds rudimentary hOCR output support. Notes:

- Currently it just adds bounding boxes, not baselines (which are also supported) to the hOCR output
- It doesn't add any semantic layout stuff; instead, it just represents each word as an `ocrx_word`
- Some of the metadata could be improved, such as adding the real image name and perhaps EasyOCR version number
- I didn't check if EasyOCR supports multipage inputs; this will certainly break with those if it does

- I left this comment in the source code; I'm not sure what to do with it (probably shouldn't be enabled by default):

```python
# In order to get a browser-renderable HTML file, you can add this before the closing </body> tag:
#
# <script src="https://unpkg.com/hocrjs"></script>
```

Other than that, I validated the output with `hocr-check` from https://github.com/ocropus/hocr-tools and also checked that it validates as XHTML.