### PR TITLE
Fix: Resolves memory leak caused by using CRAFT detector with detect() or readtext().

### DIFF
--- a/easyocr/detection.py
+++ b/easyocr/detection.py
@@ -74,7 +74,8 @@ def test_net(canvas_size, mag_ratio, net, image, text_threshold, link_threshold,
     
     # remove y from device, whether GPU or CPU, and call empty_cache() to clean up
     del y
-    torch.cuda.empty_cache()
+    if cuda:
+        torch.cuda.empty_cache()
 
     return boxes_list, polys_list
 

--- a/easyocr/detection.py
+++ b/easyocr/detection.py
@@ -45,6 +45,9 @@ def test_net(canvas_size, mag_ratio, net, image, text_threshold, link_threshold,
     with torch.no_grad():
         y, feature = net(x)
 
+    # remove x and feature from device, whether GPU or CPU
+    del x, feature
+
     boxes_list, polys_list = [], []
     for out in y:
         # make score and link map
@@ -68,6 +71,10 @@ def test_net(canvas_size, mag_ratio, net, image, text_threshold, link_threshold,
                 polys[k] = boxes[k]
         boxes_list.append(boxes)
         polys_list.append(polys)
+    
+    # remove y from device, whether GPU or CPU, and call empty_cache() to clean up
+    del y
+    torch.cuda.empty_cache()
 
     return boxes_list, polys_list
 

--- a/easyocr/detection.py
+++ b/easyocr/detection.py
@@ -72,9 +72,9 @@ def test_net(canvas_size, mag_ratio, net, image, text_threshold, link_threshold,
         boxes_list.append(boxes)
         polys_list.append(polys)
     
-    # remove y from device, whether GPU or CPU, and call empty_cache() to clean up
+    # remove y from device, whether GPU or CPU, and check if cuda was used before calling empty_cache() to clean up
     del y
-    if cuda:
+    if device == 'cuda':
         torch.cuda.empty_cache()
 
     return boxes_list, polys_list


### PR DESCRIPTION
This fix enables garbage collection to appropriately work when https://github.com/JaidedAI/EasyOCR/blob/c999505ef6b43be1c4ee36aa04ad979175178352/easyocr/detection.py#L24 returns, by deleting the objects we moved to the GPU after we move the forward pass results back on the CPU.

See https://pytorch.org/blog/understanding-gpu-memory-2/#why-doesnt-automatic-garbage-collection-work for more detail.

Running `torch.cuda.empty_cache()` in `test_net()` before returning allows nvidia-smi to be accurate.

Interestingly, nvidia-smi showed that GPU memory usage per process was 204MiB upon reader initialization, and then would increase to 234MiB or 288MiB after running `easyocr.reader.detect()`, but then not increase beyond that point and in some cases reduce back down to 234MiB. I think this has something to do with 

One note is that I tested this on a single GPU machine where I changed https://github.com/JaidedAI/EasyOCR/blob/c999505ef6b43be1c4ee36aa04ad979175178352/easyocr/detection.py#L86 to be `net = net.to(device)`, removing DataParallel. There's no reason this shouldn't work on multi-GPU machines, but noting it wasn't tested on one.

I also only tested this on the CRAFT detector, not DBNet.

**Relevant package versions**
easyocr version 1.7.1
torch version 2.2.1+cu121
torchvision 0.17.1+cu121

Hope this helps!