### PR TITLE
Fix: import get_display

### DIFF
--- a/easyocr/easyocr.py
+++ b/easyocr/easyocr.py
@@ -6,7 +6,7 @@ from .utils import group_text_box, get_image_list, calculate_md5, get_paragraph,
                    make_rotated_img_list, set_result_with_confidence,\
                    reformat_input_batched, merge_to_free
 from .config import *
-from bidi.algorithm import get_display
+from bidi import get_display
 import numpy as np
 import cv2
 import torch


### PR DESCRIPTION
Fix get display import "from bidi import get_display" and no longer from "bidi.algorithm import get_display" this PR aim to fix that issue.