### PR TITLE
Fix: bidi instead of bidi.algorithm

### DIFF
--- a/easyocr/easyocr.py
+++ b/easyocr/easyocr.py
@@ -6,7 +6,7 @@ from .utils import group_text_box, get_image_list, calculate_md5, get_paragraph,
                    make_rotated_img_list, set_result_with_confidence,\
                    reformat_input_batched, merge_to_free
 from .config import *
-from bidi.algorithm import get_display
+from bidi import get_display
 import numpy as np
 import cv2
 import torch


### PR DESCRIPTION
previous implementation was good for python-bidi version in 0.4.2 as they used bidi.algorithm.

Now from bidi version onwards 0.5.0 they use bidi only