### PR TITLE
fix FutureWarning in torch.load, since torch 2.3.1

### DIFF
--- a/easyocr/detection.py
+++ b/easyocr/detection.py
@@ -82,7 +82,7 @@ def get_detector(trained_model, device='cpu', quantize=True, cudnn_benchmark=Fal
             except:
                 pass
     else:
-        net.load_state_dict(copyStateDict(torch.load(trained_model, map_location=device)))
+        net.load_state_dict(copyStateDict(torch.load(trained_model, map_location=device, weights_only=True)))
         net = torch.nn.DataParallel(net).to(device)
         cudnn.benchmark = cudnn_benchmark
 

--- a/easyocr/recognition.py
+++ b/easyocr/recognition.py
@@ -179,7 +179,7 @@ def get_recognizer(recog_network, network_params, character,\
                 pass
     else:
         model = torch.nn.DataParallel(model).to(device)
-        model.load_state_dict(torch.load(model_path, map_location=device))
+        model.load_state_dict(torch.load(model_path, map_location=device, weights_only=True))
 
     return model, converter
 

--- a/unit_test/README.md
+++ b/unit_test/README.md
@@ -9,7 +9,7 @@ This module can be used as a typical python module. One python wrapper script an
 ### Python script (*recommneded*)
 The script can be called with (assuming calling from `EasyOCR/`);
 ```
-python ./unit_test/run_unit_test.py --easyocr ./easyocr --verbose 2 --test ./unit_test/EasyOcrUnitTestPackage.pickle --data_dir ./examples 
+python ./unit_test/run_unit_test.py --easyocr ./easyocr --verbose 2 --test_data ./unit_test/data/EasyOcrUnitTestPackage.pickle --image_data_dir ./examples 
 ```
 
 #### Script arguments


### PR DESCRIPTION
Since with torch 2.3.1, it complains followings:
* The commit here has explicit usage of weights_only with True.
* The running unit test results show all passed. (I correct the running command in ./unit_test/README.md, which had incorrect argument names)
* Functional test with various image files works fine as well.
```
/home/bkim/.local/lib/python3.8/site-packages/easyocr/detection.py:85: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
  net.load_state_dict(copyStateDict(torch.load(trained_model, map_location=device)))
/home/bkim/.local/lib/python3.8/site-packages/easyocr/recognition.py:182: FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
  model.load_state_dict(torch.load(model_path, map_location=device))
```