### PR TITLE
Support non-ASCII file paths for images

### DIFF
--- a/easyocr/DBNet/DBNet.py
+++ b/easyocr/DBNet/DBNet.py
@@ -217,7 +217,7 @@ class DBNet:
         '''
         if isinstance(image, str):
             if os.path.isfile(image):
-                image = cv2.imread(image, cv2.IMREAD_COLOR).astype('float32')
+                image = cv2.imdecode(np.fromfile(image.replace('\\','/'), dtype=np.uint8), cv2.IMREAD_COLOR).astype('float32')
             else:
                 raise FileNotFoundError("Cannot find {}".format(image))
         elif isinstance(image, np.ndarray):

--- a/easyocr/utils.py
+++ b/easyocr/utils.py
@@ -736,7 +736,7 @@ def reformat_input(image):
             img_cv_grey = cv2.imread(tmp, cv2.IMREAD_GRAYSCALE)
             os.remove(tmp)
         else:
-            img_cv_grey = cv2.imread(image, cv2.IMREAD_GRAYSCALE)
+            img_cv_grey = cv2.imdecode(np.fromfile(image.replace('\\','/'), dtype=np.uint8), cv2.IMREAD_GRAYSCALE) # numpy can handle non-ASCII file paths
             image = os.path.expanduser(image)
         img = loadImage(image)  # can accept URL
     elif type(image) == bytes:

--- a/trainer/craft/data/dataset.py
+++ b/trainer/craft/data/dataset.py
@@ -263,7 +263,7 @@ class SynthTextDataSet(CraftBaseDataset):
 
     def make_gt_score(self, index):
         img_path = os.path.join(self.data_dir, self.img_names[index][0])
-        image = cv2.imread(img_path, cv2.IMREAD_COLOR)
+        image = cv2.imdecode(np.fromfile(img_path.replace('\\','/'), dtype=np.uint8), cv2.IMREAD_COLOR)
         image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
         all_char_bbox = self.char_bbox[index].transpose(
             (2, 1, 0)
@@ -388,7 +388,7 @@ class CustomDataset(CraftBaseDataset):
     def load_data(self, index):
         img_name = self.img_names[index]
         img_path = os.path.join(self.img_dir, img_name)
-        image = cv2.imread(img_path)
+        image = cv2.imdecode(np.fromfile(img_path.replace('\\','/'), dtype=np.uint8), cv2.IMREAD_COLOR)
         image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
 
         img_gt_box_path = os.path.join(
@@ -491,7 +491,7 @@ class CustomDataset(CraftBaseDataset):
         """
         img_name = self.img_names[index]
         img_path = os.path.join(self.img_dir, img_name)
-        image = cv2.imread(img_path)
+        image = cv2.imdecode(np.fromfile(img_path.replace('\\','/'), dtype=np.uint8), cv2.IMREAD_COLOR)
         image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
 
         img_gt_box_path = os.path.join(
@@ -512,9 +512,9 @@ class CustomDataset(CraftBaseDataset):
         saved_cf_mask_path = os.path.join(
             self.saved_gt_dir, f"res_img_{query_idx}_cf_mask_thresh_0.6.jpg"
         )
-        region_score = cv2.imread(saved_region_scores_path, cv2.IMREAD_GRAYSCALE)
-        affinity_score = cv2.imread(saved_affi_scores_path, cv2.IMREAD_GRAYSCALE)
-        confidence_mask = cv2.imread(saved_cf_mask_path, cv2.IMREAD_GRAYSCALE)
+        region_score = cv2.imdecode(np.fromfile(saved_region_scores_path.replace('\\','/'), dtype=np.uint8), cv2.IMREAD_GRAYSCALE)
+        affinity_score = cv2.imdecode(np.fromfile(saved_affi_scores_path.replace('\\','/'), dtype=np.uint8), cv2.IMREAD_GRAYSCALE)
+        confidence_mask = cv2.imdecode(np.fromfile(saved_cf_mask_path.replace('\\','/'), dtype=np.uint8), cv2.IMREAD_GRAYSCALE)
 
         region_score = cv2.resize(region_score, (img_w, img_h))
         affinity_score = cv2.resize(affinity_score, (img_w, img_h))

--- a/trainer/craft/eval.py
+++ b/trainer/craft/eval.py
@@ -279,7 +279,7 @@ def main_eval(model_path, backbone, config, evaluator, result_dir, buffer, model
     # -----------------------------------------------------------------------------------------------------------------#
     total_imgs_bboxes_pre = []
     for k, img_path in enumerate(tqdm(piece_imgs_path)):
-        image = cv2.imread(img_path)
+        image = cv2.imdecode(np.fromfile(img_path.replace('\\','/'), dtype=np.uint8), cv2.IMREAD_COLOR)
         image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
         single_img_bbox = []
         bboxes, polys, score_text = test_net(

--- a/trainer/craft/utils/inference_boxes.py
+++ b/trainer/craft/utils/inference_boxes.py
@@ -222,7 +222,7 @@ def load_icdar2015_gt(dataFolder, isTraing=False):
             .replace(".txt", ".jpg")
             .replace("gt_", "")
         )
-        image = cv2.imread(img_path)
+        image = cv2.imdecode(np.fromfile(img_path.replace('\\','/'), dtype=np.uint8), cv2.IMREAD_COLOR)
         lines = open(gt_path, encoding="utf-8").readlines()
         single_img_bboxes = []
         for line in lines:
@@ -270,7 +270,6 @@ def load_icdar2013_gt(dataFolder, isTraing=False):
             .replace(".txt", ".jpg")
             .replace("gt_", "")
         )
-        image = cv2.imread(img_path)
         lines = open(gt_path, encoding="utf-8").readlines()
         single_img_bboxes = []
         for line in lines:

--- a/unit_test/README.md
+++ b/unit_test/README.md
@@ -9,7 +9,7 @@ This module can be used as a typical python module. One python wrapper script an
 ### Python script (*recommneded*)
 The script can be called with (assuming calling from `EasyOCR/`);
 ```
-python ./unit_test/run_unit_test.py --easyocr ./easyocr --verbose 2 --test ./unit_test/EasyOcrUnitTestPackage.pickle --data_dir ./examples 
+python ./unit_test/run_unit_test.py --easyocr ./easyocr --verbose 2 --test_data ./unit_test/data/EasyOcrUnitTestPackage.pickle --image_data_dir ./examples
 ```
 
 #### Script arguments
@@ -21,7 +21,7 @@ python ./unit_test/run_unit_test.py --easyocr ./easyocr --verbose 2 --test ./uni
     * 3: Same as 2 and also the calculated and the expected outputs of each test.
     * 4 or higher: Same as 3 and also the inputs of each test. (This will produce a lot of text on console).
  * test_data (-t): [Optional] Path to test package to use (The default is `./unit_test/data/EasyOcrUnitTestPackage.pickle`).
- * data_dir (-d): [Optional] Path to EasyOCR example images directory. (The default is `./examples/`
+ * image_data_dir (-d): [Optional] Path to EasyOCR example images directory. (The default is `./examples`)
  
 ### Ipython notebook
 Please see `demo.ipynb` for documentation.

--- a/unit_test/run_unit_test.py
+++ b/unit_test/run_unit_test.py
@@ -12,8 +12,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Script to run EasyOCR unit tet.",
                                      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("--easyocr", help="Directory of EasyOCR to test.")
-    parser.add_argument("-t", "--test_data", default="./data/EasyOcrUnitTestPackage.pickle", help="Path to test data.")
-    parser.add_argument("-d", "--image_data_dir", default="../examples", help="Path to directory that contains EasyOCR example images.")
+    parser.add_argument("-t", "--test_data", default="./unit_test/data/EasyOcrUnitTestPackage.pickle", help="Path to test data.")
+    parser.add_argument("-d", "--image_data_dir", default="./examples", help="Path to directory that contains EasyOCR example images.")
     parser.add_argument("-v", "--verbose", default=0, type = int, help="Verbosity level of report.")
     args = parser.parse_args()
     main(args)


### PR DESCRIPTION
Read images from path using np.fromfile instead of cv2.imread for file paths that could contain non-ASCII characters; then cv2.imdecode.

Fix unit test documentation.