### PR TITLE
Fix KeyError when data_filtering_off set to True

### DIFF
--- a/trainer/dataset.py
+++ b/trainer/dataset.py
@@ -150,7 +150,7 @@ class OCRDataset(Dataset):
         self.nSamples = len(self.df)
 
         if self.opt.data_filtering_off:
-            self.filtered_index_list = [index + 1 for index in range(self.nSamples)]
+            self.filtered_index_list = [index for index in range(self.nSamples)]
         else:
             self.filtered_index_list = []
             for index in range(self.nSamples):


### PR DESCRIPTION
While training, when data_filtering_off is set to True, the elements in the index list were being incremented by 1, causing an off-by-one KeyError for the dataloader. 

This PR solves #757, #869 