### PR TITLE
Add optional verbose parameter to hide progress bar

### DIFF
--- a/easyocr/easyocr.py
+++ b/easyocr/easyocr.py
@@ -451,7 +451,7 @@ class Reader(object):
         Parameters:
         image: file path or numpy-array or a byte stream object
         '''
-        img, img_cv_grey = reformat_input(image)
+        img, img_cv_grey = reformat_input(image, verbose=self.verbose)
 
         horizontal_list, free_list = self.detect(img, 
                                                  min_size = min_size, text_threshold = text_threshold,\

--- a/easyocr/utils.py
+++ b/easyocr/utils.py
@@ -729,10 +729,14 @@ def printProgressBar(prefix='', suffix='', decimals=1, length=100, fill='█'):
 
     return progress_hook
 
-def reformat_input(image):
+def reformat_input(image, verbose=True):
     if type(image) == str:
         if image.startswith('http://') or image.startswith('https://'):
-            tmp, _ = urlretrieve(image , reporthook=printProgressBar(prefix = 'Progress:', suffix = 'Complete', length = 50))
+            reportHook = printProgressBar(prefix = 'Progress:', suffix = 'Complete', length = 50)
+            if not verbose:
+                reportHook = None
+
+            tmp, _ = urlretrieve(image , reporthook=reportHook)
             img_cv_grey = cv2.imread(tmp, cv2.IMREAD_GRAYSCALE)
             os.remove(tmp)
         else:


### PR DESCRIPTION
A progress bar is displayed whenever the Reader::readText function is called with a network URL. This pull request adds the verbose parameter to suppress the progress bar.

references #1390 
fixes #1390 