### PR TITLE
Fix: trailing slash after MODULE_PATH

### DIFF
--- a/easyocr/easyocr.py
+++ b/easyocr/easyocr.py
@@ -54,16 +54,13 @@ class Reader(object):
         self.verbose = verbose
         self.download_enabled = download_enabled
 
-        self.model_storage_directory = MODULE_PATH + '/model'
-        if model_storage_directory:
-            self.model_storage_directory = model_storage_directory
+        self.model_storage_directory = model_storage_directory or os.path.join(MODULE_PATH, 'model')
         Path(self.model_storage_directory).mkdir(parents=True, exist_ok=True)
 
-        self.user_network_directory = MODULE_PATH + '/user_network'
-        if user_network_directory:
-            self.user_network_directory = user_network_directory
+        self.user_network_directory = user_network_directory or os.path.join(MODULE_PATH, 'user_network')
         Path(self.user_network_directory).mkdir(parents=True, exist_ok=True)
         sys.path.append(self.user_network_directory)
+
 
         if gpu is False:
             self.device = 'cpu'


### PR DESCRIPTION
# Fix double-slash in EasyOCR paths

**Before:**
    # tried to load:
    '/root/.EasyOCR//user_network/my_model.yaml'

**After:**
    # now loads:
    '/root/.EasyOCR/user_network/my_model.yaml'

**What changed:**
- Replaced `MODULE_PATH + '/model'` / `+ '/user_network'` with  
    `os.path.join(MODULE_PATH, 'model')` and  
    `os.path.join(MODULE_PATH, 'user_network')`
- Kept `Path(...).mkdir(parents=True, exist_ok=True)` and `sys.path.append(...)`

**Why:**
Manual `+ '/…'` concatenation could produce `//` and cause file-not-found errors. `os.path.join()` fixes separators so custom models always load correctly.

**Tested in:**
- Standard environment ✅  
- Virtualenvs ✅  