### PR TITLE
Make md5 usage compatible with FIBS enabled environments

### DIFF
--- a/easyocr/utils.py
+++ b/easyocr/utils.py
@@ -631,7 +631,7 @@ def download_and_unzip(url, filename, model_storage_directory, verbose=True):
     os.remove(zip_path)
 
 def calculate_md5(fname):
-    hash_md5 = hashlib.md5()
+    hash_md5 = hashlib.md5(usedforsecurity=False)
     with open(fname, "rb") as f:
         for chunk in iter(lambda: f.read(4096), b""):
             hash_md5.update(chunk)


### PR DESCRIPTION
The current way of using MD5 is calling it directly but this does not work with FIBS enabled environments. Since this is not a security use case of MD5 we can set the flag of usedforsecurity=False

This enables the FIBS environments to use this package.